### PR TITLE
WIP

### DIFF
--- a/CoreInteractiveGraph/src/au/gov/asd/tac/constellation/graph/interaction/visual/InteractiveVKVisualProcessor.java
+++ b/CoreInteractiveGraph/src/au/gov/asd/tac/constellation/graph/interaction/visual/InteractiveVKVisualProcessor.java
@@ -88,13 +88,13 @@ public class InteractiveVKVisualProcessor extends CVKVisualProcessor implements 
      * @param printGlCapabilities Whether or not to print out a list of GL
      * capabilities upon initialisation.
      */
-    public InteractiveVKVisualProcessor() throws Throwable {
-        super();
+    public InteractiveVKVisualProcessor(final String graphId) throws Throwable {
+        super(graphId);
 //        setGraphDisplayer(graphDisplayer);
 //        addRenderable(newLineRenderable);
 //        addRenderable(selectionBoxRenderable);
 //        addRenderable(planesRenderable);
-        hitTester = new CVKHitTester();//this);
+        hitTester = new CVKHitTester(this);
         addRenderable(hitTester);
     }
 

--- a/CoreInteractiveGraph/src/au/gov/asd/tac/constellation/graph/interaction/visual/VKInteractiveVisualManagerFactory.java
+++ b/CoreInteractiveGraph/src/au/gov/asd/tac/constellation/graph/interaction/visual/VKInteractiveVisualManagerFactory.java
@@ -33,7 +33,7 @@ public class VKInteractiveVisualManagerFactory extends GraphVisualManagerFactory
     public VisualManager constructVisualManager(Graph graph) throws Throwable {
         final VisualAccess access = new GraphVisualAccess(graph);
         final Preferences prefs = NbPreferences.forModule(DeveloperPreferenceKeys.class);
-        final InteractiveVKVisualProcessor processor = new InteractiveVKVisualProcessor();
+        final InteractiveVKVisualProcessor processor = new InteractiveVKVisualProcessor(graph.getId());
         final VisualManager manager = new VisualManager(access, processor);
         final GraphChangeListener changeDetector = event -> manager.updateFromIndigenousChanges();
         final DefaultInteractionEventHandler eventHandler = new DefaultInteractionEventHandler(graph, manager, processor, processor);

--- a/CoreInteractiveGraph/src/au/gov/asd/tac/constellation/graph/interaction/visual/renderables/CVKHitTester.java
+++ b/CoreInteractiveGraph/src/au/gov/asd/tac/constellation/graph/interaction/visual/renderables/CVKHitTester.java
@@ -17,10 +17,9 @@ package au.gov.asd.tac.constellation.graph.interaction.visual.renderables;
 
 import au.gov.asd.tac.constellation.graph.interaction.framework.HitState;
 import au.gov.asd.tac.constellation.graph.interaction.framework.HitState.HitType;
-import au.gov.asd.tac.constellation.visual.vulkan.CVKDescriptorPool;
 import au.gov.asd.tac.constellation.visual.vulkan.CVKDescriptorPool.CVKDescriptorPoolRequirements;
 import au.gov.asd.tac.constellation.visual.vulkan.CVKDevice;
-import au.gov.asd.tac.constellation.visual.vulkan.CVKSwapChain;
+import au.gov.asd.tac.constellation.visual.vulkan.CVKVisualProcessor;
 import au.gov.asd.tac.constellation.visual.vulkan.renderables.CVKRenderable;
 import java.util.LinkedList;
 import java.util.Queue;
@@ -47,6 +46,10 @@ public class CVKHitTester extends CVKRenderable {
     
     
     // ========================> Lifetime <======================== \\
+    
+    public CVKHitTester(CVKVisualProcessor parent) {
+        this.parent = parent;
+    }
     
     @Override
     public int Initialise(CVKDevice cvkDevice) { return VK_SUCCESS;}  

--- a/CoreVulkanDisplay/src/au/gov/asd/tac/constellation/visual/vulkan/CVKCanvas.java
+++ b/CoreVulkanDisplay/src/au/gov/asd/tac/constellation/visual/vulkan/CVKCanvas.java
@@ -6,10 +6,7 @@
 package au.gov.asd.tac.constellation.visual.vulkan;
 
 import java.awt.Graphics;
-import java.util.ArrayList;
-import java.util.EventListener;
 import org.lwjgl.vulkan.awt.AWTVKCanvas;
-
 import javax.swing.SwingUtilities;
 import org.lwjgl.vulkan.awt.VKData;
 
@@ -18,29 +15,25 @@ import org.lwjgl.vulkan.awt.VKData;
 public class CVKCanvas extends AWTVKCanvas{
     private boolean parentAdded = false;
     private int frameNumber = 0;
-    private final CVKRenderer vkRenderer;
-    private ArrayList<EventListener> eventListeners = new ArrayList<>();
+    private final CVKRenderer cvkRenderer;
     
     public int GetFrameNumber() { return frameNumber; }
     
-    public CVKCanvas(VKData vkData, CVKRenderer vkRenderer) {
+    public CVKCanvas(VKData vkData, CVKRenderer cvkRenderer) {
         super(vkData);
-        this.vkRenderer = vkRenderer;
-        this.addComponentListener(vkRenderer);
+        cvkRenderer.Logger().fine("Canvas constructed");        
+        this.cvkRenderer = cvkRenderer;
+        this.addComponentListener(cvkRenderer);
     }
-   
-
+  
     public void Destroy() {
-        this.removeComponentListener(vkRenderer);
+        cvkRenderer.Logger().fine("Canvas destroyed"); 
+        this.removeComponentListener(cvkRenderer);
     }
-    
     
     public void InitSurface() {
+        cvkRenderer.Logger().fine("Canvas InitSurface"); 
         parentAdded = true;
-    }
-    
-    public void addEventListener(EventListener listener) {
-        eventListeners.add(listener);
     }
     
     @Override
@@ -62,6 +55,7 @@ public class CVKCanvas extends AWTVKCanvas{
     */
     @Override
     public boolean requestFocusInWindow() {
+        cvkRenderer.Logger().fine("Canvas requestFocusInWindow"); 
         boolean ret = super.requestFocusInWindow();
         parentAdded = true;
         return ret;
@@ -69,7 +63,8 @@ public class CVKCanvas extends AWTVKCanvas{
     
     @Override
     public void initVK() {
-        vkRenderer.Initialise(this.surface);
+        cvkRenderer.Logger().fine("Canvas initVK"); 
+        cvkRenderer.Initialise(this.surface);
     }
     
     @Override
@@ -78,7 +73,7 @@ public class CVKCanvas extends AWTVKCanvas{
         // CVKRenderer is ready to use.  platformCanvas is private in our parent 
         // so this is the only way to complete the surface initialisation.  
         ++frameNumber;       
-        vkRenderer.Display();
+        cvkRenderer.Display();
     }
     
     @Override

--- a/CoreVulkanDisplay/src/au/gov/asd/tac/constellation/visual/vulkan/CVKDescriptorPool.java
+++ b/CoreVulkanDisplay/src/au/gov/asd/tac/constellation/visual/vulkan/CVKDescriptorPool.java
@@ -16,8 +16,6 @@
 package au.gov.asd.tac.constellation.visual.vulkan;
 
 import static au.gov.asd.tac.constellation.visual.vulkan.utils.CVKUtils.CVKAssert;
-import static au.gov.asd.tac.constellation.visual.vulkan.utils.CVKUtils.CVKLOGGER;
-import static au.gov.asd.tac.constellation.visual.vulkan.utils.CVKUtils.VerifyInRenderThread;
 import static au.gov.asd.tac.constellation.visual.vulkan.utils.CVKUtils.checkVKret;
 import java.nio.LongBuffer;
 import org.lwjgl.system.MemoryStack;
@@ -106,7 +104,7 @@ public class CVKDescriptorPool {
                              final int imageCount,
                              final CVKDescriptorPoolRequirements poolReqs,
                              final CVKDescriptorPoolRequirements perImagePoolReqs) {
-        VerifyInRenderThread();
+        cvkDevice.VerifyInRenderThread();
         CVKAssert(cvkDevice != null);
         CVKAssert(imageCount > 0);
         CVKAssert(poolReqs != null);
@@ -147,7 +145,7 @@ public class CVKDescriptorPool {
                         VkDescriptorPoolSize vkPoolSize = pPoolSizes.get(iPoolSize++);
                         vkPoolSize.type(iType);
                         vkPoolSize.descriptorCount(count);
-                        CVKLOGGER.info(String.format("Descriptor pool type %d = count %d", iType, count));                                        
+                        cvkDevice.Logger().info("Descriptor pool type %d = count %d", iType, count);                                        
                     } 
                 }           
 
@@ -158,7 +156,7 @@ public class CVKDescriptorPool {
                 poolInfo.flags(VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT);
                 poolInfo.pPoolSizes(pPoolSizes);
                 poolInfo.maxSets(cvkDescriptorPoolRequirements.poolDesciptorSetCount);
-                CVKLOGGER.info(String.format("Descriptor pool maxSets = %d", cvkDescriptorPoolRequirements.poolDesciptorSetCount));  
+                cvkDevice.Logger().info("Descriptor pool maxSets = %d", cvkDescriptorPoolRequirements.poolDesciptorSetCount);  
 
                 LongBuffer pDescriptorPool = stack.mallocLong(1);
                 ret = vkCreateDescriptorPool(cvkDevice.GetDevice(), poolInfo, null, pDescriptorPool);
@@ -174,6 +172,6 @@ public class CVKDescriptorPool {
         vkDestroyDescriptorPool(cvkDevice.GetDevice(), hDescriptorPool, null);
         hDescriptorPool = VK_NULL_HANDLE;
         cvkDevice = null;
-        CVKLOGGER.info("Destroyed descriptor pool");
+        cvkDevice.Logger().info("Destroyed descriptor pool");
     }    
 }

--- a/CoreVulkanDisplay/src/au/gov/asd/tac/constellation/visual/vulkan/CVKInstance.java
+++ b/CoreVulkanDisplay/src/au/gov/asd/tac/constellation/visual/vulkan/CVKInstance.java
@@ -15,7 +15,7 @@
  */
 package au.gov.asd.tac.constellation.visual.vulkan;
 
-import static au.gov.asd.tac.constellation.visual.vulkan.utils.CVKUtils.CVKLOGGER;
+import static au.gov.asd.tac.constellation.visual.vulkan.utils.CVKGraphLogger.CVKLOGGER;
 import static au.gov.asd.tac.constellation.visual.vulkan.utils.CVKUtils.VkFailed;
 import static au.gov.asd.tac.constellation.visual.vulkan.utils.CVKUtils.VkSucceeded;
 import static au.gov.asd.tac.constellation.visual.vulkan.utils.CVKUtils.checkVKret;
@@ -52,7 +52,6 @@ import org.lwjgl.vulkan.VkInstanceCreateInfo;
 public class CVKInstance {
     private static CVKInstance cvkInstance = null;
     private VkInstance vkInstance = null;
-    
     
     private CVKInstance() {}
     public static CVKInstance GetInstance(MemoryStack stack, PointerBuffer pbExtensions, PointerBuffer pbValidationLayers, boolean debugging) {

--- a/CoreVulkanDisplay/src/au/gov/asd/tac/constellation/visual/vulkan/renderables/CVKAxesRenderable.java
+++ b/CoreVulkanDisplay/src/au/gov/asd/tac/constellation/visual/vulkan/renderables/CVKAxesRenderable.java
@@ -83,12 +83,11 @@ import au.gov.asd.tac.constellation.utilities.graphics.Vector4f;
 import au.gov.asd.tac.constellation.visual.vulkan.CVKDescriptorPool.CVKDescriptorPoolRequirements;
 import static au.gov.asd.tac.constellation.visual.vulkan.utils.CVKShaderUtils.ShaderKind.GEOMETRY_SHADER;
 import static au.gov.asd.tac.constellation.visual.vulkan.utils.CVKUtils.CVKAssert;
-import static au.gov.asd.tac.constellation.visual.vulkan.utils.CVKUtils.CVKLOGGER;
-import static au.gov.asd.tac.constellation.visual.vulkan.utils.CVKUtils.VerifyInRenderThread;
 import static au.gov.asd.tac.constellation.visual.vulkan.utils.CVKUtils.VkFailed;
 import au.gov.asd.tac.constellation.visual.vulkan.CVKVisualProcessor;
 import au.gov.asd.tac.constellation.visual.vulkan.resourcetypes.CVKBuffer;
 import au.gov.asd.tac.constellation.visual.vulkan.resourcetypes.CVKCommandBuffer;
+import static au.gov.asd.tac.constellation.visual.vulkan.utils.CVKGraphLogger.CVKLOGGER;
 import static au.gov.asd.tac.constellation.visual.vulkan.utils.CVKUtils.CVK_ERROR_SHADER_COMPILATION;
 import static au.gov.asd.tac.constellation.visual.vulkan.utils.CVKUtils.CVK_ERROR_SHADER_MODULE;
 import java.nio.IntBuffer;
@@ -389,7 +388,7 @@ public class CVKAxesRenderable extends CVKRenderable {
     * object to cleanup its resources.
     */
     private int CreateSwapChainResources() {
-        VerifyInRenderThread();
+        parent.VerifyInRenderThread();
         CVKAssert(cvkSwapChain != null);
         int ret = VK_SUCCESS;
 
@@ -422,7 +421,7 @@ public class CVKAxesRenderable extends CVKRenderable {
     
     @Override
     protected int DestroySwapChainResources(){
-        VerifyInRenderThread();
+        parent.VerifyInRenderThread();
         int ret = VK_SUCCESS;
         
         // We only need to recreate these resources if the number of images in 
@@ -685,7 +684,7 @@ public class CVKAxesRenderable extends CVKRenderable {
             commandBuffers.add(buffer);
         }
         
-        CVKLOGGER.log(Level.INFO, "Init Command Buffer - AxesRenderable");
+        cvkDevice.Logger().log(Level.INFO, "Init Command Buffer - AxesRenderable");
         
         return ret;
     }
@@ -698,7 +697,7 @@ public class CVKAxesRenderable extends CVKRenderable {
     @Override
     public int RecordCommandBuffer(VkCommandBufferInheritanceInfo inheritanceInfo, int imageIndex) {
         CVKAssert(cvkSwapChain != null);
-        VerifyInRenderThread();
+        parent.VerifyInRenderThread();
         int ret;
         
         try (MemoryStack stack = stackPush()) {
@@ -973,7 +972,7 @@ public class CVKAxesRenderable extends CVKRenderable {
                 CVKAssert(pipelines.get(i) != VK_NULL_HANDLE);
             }
         }
-        CVKLOGGER.log(Level.INFO, "Graphics Pipeline created for AxesRenderable class.");
+        cvkDevice.Logger().log(Level.INFO, "Graphics Pipeline created for AxesRenderable class.");
         
         return ret;
     }
@@ -999,7 +998,7 @@ public class CVKAxesRenderable extends CVKRenderable {
 
     @Override
     public int DisplayUpdate() { 
-        VerifyInRenderThread();
+        parent.VerifyInRenderThread();
         
         int ret = VK_SUCCESS;    
         
@@ -1029,7 +1028,7 @@ public class CVKAxesRenderable extends CVKRenderable {
         
         //=== EXECUTED BY RENDER THREAD (during CVKVisualProcessor.ProcessRenderTasks) ===//
         return () -> {
-            VerifyInRenderThread();                      
+            parent.VerifyInRenderThread();                      
             needsDisplayUpdate = true;
         };
     }  

--- a/CoreVulkanDisplay/src/au/gov/asd/tac/constellation/visual/vulkan/resourcetypes/CVKBuffer.java
+++ b/CoreVulkanDisplay/src/au/gov/asd/tac/constellation/visual/vulkan/resourcetypes/CVKBuffer.java
@@ -17,7 +17,6 @@ package au.gov.asd.tac.constellation.visual.vulkan.resourcetypes;
 
 import au.gov.asd.tac.constellation.visual.vulkan.CVKDevice;
 import static au.gov.asd.tac.constellation.visual.vulkan.utils.CVKUtils.CVKAssert;
-import static au.gov.asd.tac.constellation.visual.vulkan.utils.CVKUtils.CVKLOGGER;
 import static au.gov.asd.tac.constellation.visual.vulkan.utils.CVKUtils.VkFailed;
 import static au.gov.asd.tac.constellation.visual.vulkan.utils.CVKUtils.checkVKret;
 import java.nio.ByteBuffer;
@@ -47,6 +46,8 @@ import org.lwjgl.vulkan.VkBufferCopy;
 import org.lwjgl.vulkan.VkBufferCreateInfo;
 import org.lwjgl.vulkan.VkMemoryAllocateInfo;
 import org.lwjgl.vulkan.VkMemoryRequirements;
+import static au.gov.asd.tac.constellation.visual.vulkan.utils.CVKUtils.CVK_DEBUGGING;
+import static au.gov.asd.tac.constellation.visual.vulkan.utils.CVKUtils.CVK_VKALLOCATIONS;
 
 public class CVKBuffer {
     final static int COPY_SIZE = 4096; //candidate for profiling
@@ -168,26 +169,26 @@ public class CVKBuffer {
     public void DEBUGPRINT(List<DEBUG_CVKBufferElementDescriptor> typeDescriptors) {
         ByteBuffer pData = StartWrite(0, (int)bufferSize);
         
-        CVKLOGGER.info("\n");
-        CVKLOGGER.info(String.format("Contents of %s:", DEBUGNAME));
+        cvkDevice.Logger().info("\n");
+        cvkDevice.Logger().info(String.format("Contents of %s:", DEBUGNAME));
         int idx = 0;
         while (pData.hasRemaining()) {
             for (DEBUG_CVKBufferElementDescriptor desc : typeDescriptors) {
                 if (desc.type == Float.TYPE) {  
                     final float f = pData.getFloat();
-                    CVKLOGGER.info(String.format("\tidx %d\t%s:\t%f", idx, desc.label, f));
+                    cvkDevice.Logger().info(String.format("\tidx %d\t%s:\t%f", idx, desc.label, f));
                 } else if (desc.type == Integer.TYPE) {
                     final int d = pData.getInt();
-                    CVKLOGGER.info(String.format("\tidx %d\t%s:\t%d", idx, desc.label, d));
+                    cvkDevice.Logger().info(String.format("\tidx %d\t%s:\t%d", idx, desc.label, d));
                 }else {
-                    CVKLOGGER.info(String.format("CVKBuffer.DEBUGPRINT cannot handle type <%s>", desc.type.getName()));
+                    cvkDevice.Logger().info(String.format("CVKBuffer.DEBUGPRINT cannot handle type <%s>", desc.type.getName()));
                     break;
                 }
             }
             ++idx;
         }
         
-        CVKLOGGER.info("\n");
+        cvkDevice.Logger().info("\n");
         
         EndWrite();
     }
@@ -210,6 +211,15 @@ public class CVKBuffer {
     }
     
     public void Destroy() {
+        if (CVK_DEBUGGING && pBuffer != null) {
+            if (pBufferMemory != null && pBufferMemory.get(0) != VK_NULL_HANDLE) {
+                --CVK_VKALLOCATIONS;
+                cvkDevice.Logger().info(String.format("CVK_VKALLOCATIONS (%d-) Destroy called on CVKBuffer (0x%016X), vkFreeMemory will be called", CVK_VKALLOCATIONS, pBuffer.get(0)));
+            } else {
+                
+                cvkDevice.Logger().info(String.format("CVK_VKALLOCATIONS (%d!) Destroy called on CVKBuffer (0x%016X), vkFreeMemory will NOT be called", CVK_VKALLOCATIONS, pBuffer.get(0)));
+            }            
+        }
         if (pBuffer != null && pBuffer.get(0) != VK_NULL_HANDLE) {
             vkDestroyBuffer(cvkDevice.GetDevice(), pBuffer.get(0), null);
             pBuffer.put(0, VK_NULL_HANDLE);
@@ -221,7 +231,7 @@ public class CVKBuffer {
             pBufferMemory.put(0, VK_NULL_HANDLE);
             MemoryUtil.memFree(pBufferMemory);
             pBufferMemory = null;            
-        }        
+        }
     }
     
     @SuppressWarnings("deprecation")
@@ -231,6 +241,15 @@ public class CVKBuffer {
         super.finalize();
     }
     
+    /**
+     * Factory creation method for CVKBuffers
+     * 
+     * @param cvkDevice
+     * @param size
+     * @param usage
+     * @param properties
+     * @return
+     */    
     /**
      * Factory creation method for CVKBuffers
      * 
@@ -271,18 +290,22 @@ public class CVKBuffer {
             checkVKret(ret);
             
             // Calculate memory requirements based on the info we proved to the bufferInfo struct
-            VkMemoryRequirements vkMemRequirements = VkMemoryRequirements.mallocStack(stack);
-            vkGetBufferMemoryRequirements(cvkDevice.GetDevice(), cvkBuffer.pBuffer.get(0), vkMemRequirements);
+            VkMemoryRequirements vkMemoryRequirements = VkMemoryRequirements.mallocStack(stack);
+            vkGetBufferMemoryRequirements(cvkDevice.GetDevice(), cvkBuffer.pBuffer.get(0), vkMemoryRequirements);
 
             // Allocation info struct, type index needs a little logic as types can be mapped differently between GPUs
-            VkMemoryAllocateInfo vkAllocInfo = VkMemoryAllocateInfo.callocStack(stack);
-            vkAllocInfo.sType(VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO);
-            vkAllocInfo.allocationSize(vkMemRequirements.size());
-            vkAllocInfo.memoryTypeIndex(cvkDevice.GetMemoryType(vkMemRequirements.memoryTypeBits(), properties));
+            VkMemoryAllocateInfo vkAllocationInfo = VkMemoryAllocateInfo.callocStack(stack);
+            vkAllocationInfo.sType(VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO);
+            vkAllocationInfo.allocationSize(vkMemoryRequirements.size());
+            vkAllocationInfo.memoryTypeIndex(cvkDevice.GetMemoryType(vkMemoryRequirements.memoryTypeBits(), properties));
 
             // Allocate the memory needed for the buffer (still needs to be bound)
-            ret = vkAllocateMemory(cvkDevice.GetDevice(), vkAllocInfo, null, cvkBuffer.pBufferMemory);
+            ret = vkAllocateMemory(cvkDevice.GetDevice(), vkAllocationInfo, null, cvkBuffer.pBufferMemory);
             checkVKret(ret);
+            ++CVK_VKALLOCATIONS;
+            cvkDevice.Logger().info(String.format("CVK_VKALLOCATIONS(%d+) vkAllocateMemory(%d) for CVKBuffer (0x%016X)", 
+                    CVK_VKALLOCATIONS, vkMemoryRequirements.size(), cvkBuffer.pBuffer.get(0)));
+            //LogStackTrace();
 
             // We have a pen, we have a apple, we have a pineapple...err bind the buffer to its memory
             ret = vkBindBufferMemory(cvkDevice.GetDevice(), 

--- a/CoreVulkanDisplay/src/au/gov/asd/tac/constellation/visual/vulkan/resourcetypes/CVKCommandBuffer.java
+++ b/CoreVulkanDisplay/src/au/gov/asd/tac/constellation/visual/vulkan/resourcetypes/CVKCommandBuffer.java
@@ -56,7 +56,7 @@ public class CVKCommandBuffer {
     @SuppressWarnings("deprecation")
     @Override
     public void finalize() throws Throwable {	
-        //TODO remove the if, only here for debugging, its checked in Destroy()
+        //TODO remove the if, only here for CVK_DEBUGGING, its checked in Destroy()
         if (vkCommandBuffer != null) {
             Destroy();
         }
@@ -65,14 +65,14 @@ public class CVKCommandBuffer {
 
     public void Destroy(){        
         if (vkCommandBuffer != null) {
-            VerifyInRenderThread();
+            cvkDevice.VerifyInRenderThread();
             vkFreeCommandBuffers(cvkDevice.GetDevice(), cvkDevice.GetCommandPoolHandle(), vkCommandBuffer);
             vkCommandBuffer = null;
         }
     }
     
     public int Begin(int flags) {	
-        VerifyInRenderThread();
+        cvkDevice.VerifyInRenderThread();
         
         int ret;            
         try (MemoryStack stack = stackPush()) {
@@ -431,7 +431,6 @@ public class CVKCommandBuffer {
             PointerBuffer pCommandBuffer = stack.mallocPointer(1);
             ret = vkAllocateCommandBuffers(cvkDevice.GetDevice(), vkAllocateInfo, pCommandBuffer);
             checkVKret(ret);
-
 
             cvkCommandBuffer.vkCommandBuffer = new VkCommandBuffer(pCommandBuffer.get(0), cvkDevice.GetDevice());
         }

--- a/CoreVulkanDisplay/src/au/gov/asd/tac/constellation/visual/vulkan/resourcetypes/CVKImage.java
+++ b/CoreVulkanDisplay/src/au/gov/asd/tac/constellation/visual/vulkan/resourcetypes/CVKImage.java
@@ -41,11 +41,6 @@ import static org.lwjgl.vulkan.VK10.VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
 import static org.lwjgl.vulkan.VK10.VK_IMAGE_LAYOUT_UNDEFINED;
 import static org.lwjgl.vulkan.VK10.VK_IMAGE_TYPE_1D;
 import static org.lwjgl.vulkan.VK10.VK_IMAGE_TYPE_2D;
-import static org.lwjgl.vulkan.VK10.VK_IMAGE_VIEW_TYPE_1D;
-import static org.lwjgl.vulkan.VK10.VK_IMAGE_VIEW_TYPE_1D_ARRAY;
-import static org.lwjgl.vulkan.VK10.VK_IMAGE_VIEW_TYPE_2D;
-import static org.lwjgl.vulkan.VK10.VK_IMAGE_VIEW_TYPE_2D_ARRAY;
-import static org.lwjgl.vulkan.VK10.VK_NULL_HANDLE;
 import static org.lwjgl.vulkan.VK10.VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
 import static org.lwjgl.vulkan.VK10.VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT;
 import static org.lwjgl.vulkan.VK10.VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
@@ -82,7 +77,10 @@ import static au.gov.asd.tac.constellation.visual.vulkan.utils.CVKUtils.checkVKr
 import static org.lwjgl.vulkan.VK10.VK_COMMAND_BUFFER_LEVEL_PRIMARY;
 import static org.lwjgl.vulkan.VK10.VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
 import static au.gov.asd.tac.constellation.visual.vulkan.utils.CVKFormatUtils.VkFormatByteDepth;
+import static au.gov.asd.tac.constellation.visual.vulkan.utils.CVKUtils.CVK_DEBUGGING;
+import static au.gov.asd.tac.constellation.visual.vulkan.utils.CVKUtils.CVK_VKALLOCATIONS;
 import static au.gov.asd.tac.constellation.visual.vulkan.utils.CVKUtils.VkSucceeded;
+import static org.lwjgl.vulkan.VK10.VK_NULL_HANDLE;
 
 public class CVKImage {
     private CVKDevice cvkDevice     = null;
@@ -110,17 +108,28 @@ public class CVKImage {
     public int GetAspectMask() { return aspectMask; }
       
     public void Destroy() {
+        if (CVK_DEBUGGING && pImage.get(0) != VK_NULL_HANDLE) {
+            if (pImageMemory != null && pImageMemory.get(0) != VK_NULL_HANDLE) {
+                --CVK_VKALLOCATIONS;
+                cvkDevice.Logger().info(String.format("CVK_VKALLOCATIONS (%d-) Destroy called on CVKImage (0x%016X), vkFreeMemory will be called", CVK_VKALLOCATIONS, pImage.get(0)));
+            } else {
+                cvkDevice.Logger().info(String.format("CVK_VKALLOCATIONS (%d!) Destroy called on CVKImage (0x%016X), vkFreeMemory will NOT be called", CVK_VKALLOCATIONS, pImage.get(0)));
+            }            
+        }                
         if (pImage.get(0) != VK_NULL_HANDLE) {
             vkDestroyImage(cvkDevice.GetDevice(), pImage.get(0), null);
             pImage.put(0, VK_NULL_HANDLE);
+            pImage = null;
         }
         if (pImageView.get(0) != VK_NULL_HANDLE) {
             vkDestroyImageView(cvkDevice.GetDevice(), pImageView.get(0), null);
             pImageView.put(0, VK_NULL_HANDLE);
+            pImageView = null;
         }        
         if (pImageMemory.get(0) != VK_NULL_HANDLE) {
             vkFreeMemory(cvkDevice.GetDevice(), pImageMemory.get(0), null);
             pImageMemory.put(0, VK_NULL_HANDLE);
+            pImageMemory = null;
         }
         cvkDevice = null;
     }
@@ -379,6 +388,7 @@ public class CVKImage {
                                     int height,
                                     int layers,
                                     int format,
+                                    int viewType,
                                     int tiling,
                                     int usage, 
                                     int properties,
@@ -399,7 +409,7 @@ public class CVKImage {
         cvkImage.properties = properties;
         cvkImage.aspectMask = aspectMask;        
         cvkImage.imageType  = height > 1 ? VK_IMAGE_TYPE_2D : VK_IMAGE_TYPE_1D;
-        cvkImage.viewType   = layers > 1 ? (height > 1 ? VK_IMAGE_VIEW_TYPE_2D_ARRAY : VK_IMAGE_VIEW_TYPE_1D_ARRAY) : (height > 1 ? VK_IMAGE_VIEW_TYPE_2D : VK_IMAGE_VIEW_TYPE_1D);
+        cvkImage.viewType   = viewType;
         cvkImage.layout     = VK_IMAGE_LAYOUT_UNDEFINED;
          
         try(MemoryStack stack = stackPush()) {
@@ -424,17 +434,23 @@ public class CVKImage {
             assert(cvkImage.pImage.get(0) != VK_NULL_HANDLE);
 
             // The image isn't backed by memory, do that now
-            VkMemoryRequirements memRequirements = VkMemoryRequirements.mallocStack(stack);
-            vkGetImageMemoryRequirements(cvkDevice.GetDevice(), cvkImage.pImage.get(0), memRequirements);
+            VkMemoryRequirements vkMemoryRequirements = VkMemoryRequirements.mallocStack(stack);
+            vkGetImageMemoryRequirements(cvkDevice.GetDevice(), cvkImage.pImage.get(0), vkMemoryRequirements);
 
             VkMemoryAllocateInfo allocInfo = VkMemoryAllocateInfo.callocStack(stack);
             allocInfo.sType(VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO);
-            allocInfo.allocationSize(memRequirements.size());
-            allocInfo.memoryTypeIndex(cvkDevice.GetMemoryType(memRequirements.memoryTypeBits(), properties));
+            allocInfo.allocationSize(vkMemoryRequirements.size());
+            allocInfo.memoryTypeIndex(cvkDevice.GetMemoryType(vkMemoryRequirements.memoryTypeBits(), properties));
 
-            if(vkAllocateMemory(cvkDevice.GetDevice(), allocInfo, null, cvkImage.pImageMemory) != VK_SUCCESS) {
+            if (vkAllocateMemory(cvkDevice.GetDevice(), allocInfo, null, cvkImage.pImageMemory) != VK_SUCCESS) {
                 throw new RuntimeException("Failed to allocate image memory");
             }
+            if (CVK_DEBUGGING) {
+                ++CVK_VKALLOCATIONS;
+                cvkDevice.Logger().info(String.format("CVK_VKALLOCATIONS(%d+) vkAllocateMemory(%d) for CVKimage (0x%016X)", 
+                        CVK_VKALLOCATIONS, vkMemoryRequirements.size(), cvkImage.pImage.get(0)));
+            }
+//            LogStackTrace();            
 
             vkBindImageMemory(cvkDevice.GetDevice(), cvkImage.pImage.get(0), cvkImage.pImageMemory.get(0), 0);
             

--- a/CoreVulkanDisplay/src/au/gov/asd/tac/constellation/visual/vulkan/utils/CVKGraphLogger.java
+++ b/CoreVulkanDisplay/src/au/gov/asd/tac/constellation/visual/vulkan/utils/CVKGraphLogger.java
@@ -1,0 +1,293 @@
+/*
+ * Copyright 2010-2020 Australian Signals Directorate
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package au.gov.asd.tac.constellation.visual.vulkan.utils;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.logging.FileHandler;
+import java.util.logging.Formatter;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+import java.util.logging.StreamHandler;
+
+public class CVKGraphLogger {
+    // Static logger used by static code like shader loading or by code that doesn't know
+    // what graph it is working for.    
+    private final static Level DEFAULT_LOG_LEVEL = Level.ALL;    
+    public final static Logger CVKLOGGER = CreateNamedFileLogger("CVK", DEFAULT_LOG_LEVEL);    
+    
+    // Variables for the per graph loggers
+    private static final boolean INDIVIDUAL_LOGS = true; 
+    private static int NEXT_LOGGER_ID = 0;
+    private final int loggerId;
+    private int indentation = 0;
+    private final Logger graphLogger;
+    
+        
+    // ========================> Classes <======================== \\
+    
+    public static class CVKGraphLogRecord extends LogRecord {
+        public final int loggerId;
+        public final int indentation;
+        public final boolean formatted;
+        public boolean graphAnnotation;
+        
+        public CVKGraphLogRecord(Level level, String msg, final int loggerId) {
+            this(level, msg, loggerId, 0, true, true);
+        }        
+        public CVKGraphLogRecord(Level level, String msg, final int loggerId, final int indentation) {
+            this(level, msg, loggerId, indentation, true, true);
+        }
+        public CVKGraphLogRecord(Level level, String msg, final int loggerId, final int indentation, boolean formatted, boolean graphAnnotation) {
+            super(level, msg);
+            this.loggerId = loggerId;
+            this.indentation = indentation;
+            this.formatted = formatted;
+            this.graphAnnotation = graphAnnotation;
+        }        
+    }    
+    
+    public static class CVKGraphLogFormatter extends Formatter {
+        public static int indent = 0;
+        public final static int PADLEN = 40;
+        
+        @Override
+        public String format(LogRecord record) {
+            // This does all the VA_ARGS formatting
+            String msg = formatMessage(record);
+            
+            // Don't fuss about with line and file for empty lines
+            if (msg.isBlank()) {
+                return msg;
+            }
+            
+            final StackTraceElement[] stackTrace = Thread.currentThread().getStackTrace();
+            final StringBuilder lineBuilder = new StringBuilder();
+            final int indentation;
+            int stackLevel = 8; // A guesstimation based on a few observations
+            final boolean formatting;
+            final boolean graphAnnotation;
+            if (record instanceof CVKGraphLogRecord) {
+                CVKGraphLogRecord graphRecord = (CVKGraphLogRecord)record;
+                indentation = graphRecord.indentation;
+                formatting = graphRecord.formatted;
+                graphAnnotation = graphRecord.graphAnnotation;
+                if (graphAnnotation) {
+                    lineBuilder.append(String.format("[graph %d] ", graphRecord.loggerId));
+                }
+                
+                // Find the first call before CVKGraphLogger
+                int level = 0;
+                boolean encounteredCVKGraphLogger = false;
+                for (var el : stackTrace) {
+                    if (el.getClassName().endsWith("CVKGraphLogger")) {
+                        encounteredCVKGraphLogger = true;
+                    } else if (encounteredCVKGraphLogger) {
+                        stackLevel = level;
+                        break;
+                    }
+                    level++;
+                }
+            } else {
+                indentation = indent;
+                formatting = true;
+                graphAnnotation = true;
+            }
+                                    
+            if (formatting) {
+                // StartLogSection increments indent                 
+                for (int i = 0; i < indentation; ++i) {
+                    lineBuilder.append("    ");
+                }
+
+                // With a grand total of 1 observation, the call we are interested
+                // is at element 8                
+                if (stackTrace.length >= stackLevel) {
+                    StackTraceElement ste = stackTrace[stackLevel];
+                    String fileAndLine = String.format("%s:%d>", ste.getFileName(), ste.getLineNumber());
+                    lineBuilder.append(fileAndLine);                   
+
+                    // Right pad (additional to indent padding) up to PADLEN so we have 
+                    // table like output for records at the same indent level                
+                    int padding = PADLEN - fileAndLine.length();
+                    for (int i = 0; i < padding; ++i) {
+                        lineBuilder.append(" ");
+                    }                
+                }     
+            }
+            
+            StringBuilder sb = new StringBuilder();
+            String msgLines[] = msg.split("\\r?\\n");
+            for (String msgLine : msgLines) {
+                if (!msgLine.isBlank()) {
+                    sb.append(lineBuilder.toString());
+                    sb.append(msgLine);
+                }
+                sb.append(System.getProperty("line.separator"));
+            }                               
+            return sb.toString();
+        }         
+    }     
+    
+    
+    // ========================> Static Logging <======================== \\
+       
+    public static Logger CreateNamedFileLogger(String name, Level level) {        
+        Logger logger = Logger.getLogger(name);
+        logger.setUseParentHandlers(false);
+        logger.setLevel(level);
+
+        // Delete old log
+        final String logName = String.format("%s.log", name);
+        try {         
+            File oldLog = new File(logName);
+            oldLog.delete();                
+        }  
+        catch(Exception e) {   
+            // old log doesn't exist or is locked, oh well keep going
+        }  
+
+        try {
+            FileHandler fileHandler = new FileHandler(logName);
+            fileHandler.setFormatter(new CVKGraphLogFormatter());
+            logger.addHandler(fileHandler);              
+        } catch (IOException e) {
+            logger.log(Level.WARNING, "Logger failed to create {0}, exception: {1}",
+                    new Object[]{logName, e.toString()});
+        }
+
+        StreamHandler streamHanlder = new StreamHandler(System.out, new CVKGraphLogFormatter());
+        logger.addHandler(streamHanlder);   
+        
+        return logger;
+    }
+        
+//    public static void StaticStartLogSection(String msg) {
+//        CVKLOGGER.log(Level.INFO, "{0}---- START {1} ----", new Object[]{System.getProperty("line.separator"), msg});        
+//        ++CVKGraphLogFormatter.indent;
+//    }
+//    
+//    public static void StaticEndLogSection(String msg) {
+//        --CVKGraphLogFormatter.indent;
+//        CVKLOGGER.log(Level.INFO, "---- END {1} ----{0}{0}", new Object[]{System.getProperty("line.separator"), msg});        
+//    }    
+    
+    
+    // ========================> Per Graph Logging <======================== \\
+    
+    public CVKGraphLogger(String graphId) {
+        this.loggerId = NEXT_LOGGER_ID++;
+        if (INDIVIDUAL_LOGS) {
+            graphLogger = CreateNamedFileLogger(String.format("CVK_graph_%d", loggerId), DEFAULT_LOG_LEVEL);
+        } else {
+            graphLogger = null;
+        }        
+        DoLog(Level.SEVERE, String.format("Graph %s using logger %d", graphId, loggerId), loggerId, 0, false);
+    }
+    
+    private void DoLog(Level level, String msg) {
+        DoLog(level, msg, loggerId, indentation, true);
+    }
+    
+    private void DoLog(Level level, String msg, final int loggerId, final int indentation, boolean formatted) {
+        CVKGraphLogRecord record = new CVKGraphLogRecord(level, msg, loggerId, indentation, formatted, true);
+        CVKLOGGER.log(record);
+        if (graphLogger != null) {
+            record.graphAnnotation = false;
+            graphLogger.log(record);
+        }
+    }    
+    
+    public void log(Level level, String format, Object... args) {
+       if (CVKLOGGER.isLoggable(level))  {
+           String msg = String.format(format, args);
+           DoLog(level, msg);
+       }     
+    }
+    
+    public void log(Level level, String msg) {
+        if (CVKLOGGER.isLoggable(level))  {
+            DoLog(level, msg);
+        }
+    }   
+             
+    public void severe(String msg) {
+       log(Level.SEVERE, msg); 
+    }
+    public void severe(String format, Object... args) {
+       log(Level.SEVERE, format, args); 
+    }    
+    public void warning(String msg) {
+       log(Level.WARNING, msg); 
+    }
+    public void warning(String format, Object... args) {
+       log(Level.WARNING, format, args); 
+    }      
+    public void info(String msg) {
+       log(Level.INFO, msg); 
+    }
+    public void info(String format, Object... args) {
+       log(Level.INFO, format, args); 
+    }
+    public void config(String msg) {
+       log(Level.INFO, msg); 
+    }
+    public void config(String format, Object... args) {
+       log(Level.INFO, format, args); 
+    }    
+    public void fine(String msg) {
+       log(Level.FINE, msg); 
+    }
+    public void fine(String format, Object... args) {
+       log(Level.FINE, format, args); 
+    }  
+    public void finer(String msg) {
+       log(Level.FINER, msg); 
+    }
+    public void finer(String format, Object... args) {
+       log(Level.FINER, format, args); 
+    }  
+    public void finest(String msg) {
+       log(Level.FINEST, msg); 
+    }
+    public void finest(String format, Object... args) {
+       log(Level.FINEST, format, args); 
+    }       
+    
+    public void StartLogSection(String msg) {
+        StartLogSection(DEFAULT_LOG_LEVEL, msg);
+    }
+    
+    public void StartLogSection(Level level, String msg) {
+        if (CVKLOGGER.isLoggable(level))  {              
+            log(level, "%s---- START %s ----", System.getProperty("line.separator"), msg);
+            ++indentation;
+        }
+    }
+    
+    public void EndLogSection(String msg) {
+        EndLogSection(DEFAULT_LOG_LEVEL, msg);       
+    }    
+    
+    public void EndLogSection(Level level, String msg) {
+        if (CVKLOGGER.isLoggable(level))  {
+            indentation = Math.max(0, indentation - 1);
+            log(level, "---- END %s ----", msg);
+            log(level, System.getProperty("line.separator"));
+        }     
+    }     
+}

--- a/CoreVulkanDisplay/src/au/gov/asd/tac/constellation/visual/vulkan/utils/CVKUtils.java
+++ b/CoreVulkanDisplay/src/au/gov/asd/tac/constellation/visual/vulkan/utils/CVKUtils.java
@@ -16,18 +16,13 @@
 package au.gov.asd.tac.constellation.visual.vulkan.utils;
 
 import au.gov.asd.tac.constellation.utilities.graphics.Vector3f;
-import java.io.File;
+import static au.gov.asd.tac.constellation.visual.vulkan.utils.CVKGraphLogger.CVKLOGGER;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.nio.IntBuffer;
 import java.util.ArrayList;
-import java.util.logging.FileHandler;
-import java.util.logging.Formatter;
 import java.util.logging.Level;
-import java.util.logging.LogRecord;
-import java.util.logging.Logger;
-import java.util.logging.StreamHandler;
 import org.lwjgl.PointerBuffer;
 import org.lwjgl.system.MemoryStack;
 import org.lwjgl.system.Platform;
@@ -58,110 +53,19 @@ public class CVKUtils {
     public static final int CVK_ERROR_SHADER_COMPILATION                        = 0xFFFF0004;
     public static final int CVK_ERROR_SHADER_MODULE                             = 0xFFFF0005;
     
-    // Remove this once we are sure everything is working, but for now ensure all render ops happen in the render thread
-    // TODO_TT: !!!THIS WILL ONLY WORK FOR A SINGLE GRAPH, MULTIPLE GRAPHS WILL TRIP THIS !!!
-    public static long renderThreadID = 0;    
-    
     // Logger shared by all of Constellation's Vulkan classes with a minimal formatter
     // as a proxy for the IDE's console window (as prints to stdout aren't appearing).
-    public final static Logger CVKLOGGER = CreateNamedFileLogger("CVK");
-    public final static Level DEFAULT_LOG_LEVEL = Level.INFO;    
+
     
     // Enable this for additional logging, thread verification and other checks
-    public static boolean debugging = true;
+    public static boolean CVK_DEBUGGING = true;
+    
+    public static int CVK_VKALLOCATIONS = 0;
     
     
-    public static class MinimalLogFormatter extends Formatter {
-        public static int indent = 0;
-        public final static int PADLEN = 30;
-        
-        @Override
-        public String format(LogRecord record) {
-            // This does all the VA_ARGS formatting
-            String msg = formatMessage(record);
-            
-            // Don't fuss about with line and file for empty lines
-            if (msg.isBlank()) {
-                return msg;
-            }
-            
-            // StartLogSection increments indent 
-            StringBuilder lineBuilder = new StringBuilder();
-            for (int i = 0; i < indent; ++i) {
-                lineBuilder.append("    ");
-            }
-            
-            // With a grand total of 1 observation, the call we are interested
-            // is at element 8
-            StackTraceElement[] stackTrace = Thread.currentThread().getStackTrace();
-            if (stackTrace.length >= 8) {
-                StackTraceElement ste = stackTrace[8];
-                String fileAndLine = String.format("%s:%d>", ste.getFileName(), ste.getLineNumber());
-                lineBuilder.append(fileAndLine);
-                
-                // Right pad (additional to indent padding) up to PADLEN so we have 
-                // table like output for records at the same indent level                
-                int padding = PADLEN - fileAndLine.length();
-                for (int i = 0; i < padding; ++i) {
-                    lineBuilder.append(" ");
-                }                
-            }              
-            
-            StringBuilder sb = new StringBuilder();
-            String msgLines[] = msg.split("\\r?\\n");
-            for (String msgLine : msgLines) {
-                if (!msgLine.isBlank()) {
-                    sb.append(lineBuilder.toString());
-                    sb.append(msgLine);
-                }
-                sb.append(System.getProperty("line.separator"));
-            }                               
-            return sb.toString();
-        }         
-    }       
+          
     
-    public static Logger CreateNamedFileLogger(String name) {
-        return CreateNamedFileLogger(name, DEFAULT_LOG_LEVEL);
-    }
-    public static Logger CreateNamedFileLogger(String name, Level level) {        
-        Logger logger = Logger.getLogger(name);
-        logger.setUseParentHandlers(false);
-        logger.setLevel(Level.INFO);
 
-        // Delete old log
-        final String logName = String.format("%s.log", name);
-        try {         
-            File oldLog = new File(logName);
-            oldLog.delete();                
-        }  
-        catch(Exception e) {   
-            // old log doesn't exist or is locked, oh well keep going
-        }  
-
-        try {
-            FileHandler fileHandler = new FileHandler(logName);
-            fileHandler.setFormatter(new MinimalLogFormatter());
-            logger.addHandler(fileHandler);              
-        } catch (IOException e) {
-            logger.log(Level.WARNING, "Logger failed to create {0}, exception: {1}",
-                    new Object[]{logName, e.toString()});
-        }
-
-        StreamHandler streamHanlder = new StreamHandler(System.out, new MinimalLogFormatter());
-        logger.addHandler(streamHanlder);   
-        
-        return logger;
-    }
-    
-    
-    public static void StartLogSection(String msg) {
-        CVKLOGGER.log(Level.INFO, "{0}---- START {1} ----", new Object[]{System.getProperty("line.separator"), msg});        
-        ++CVKUtils.MinimalLogFormatter.indent;
-    }
-    public static void EndLogSection(String msg) {
-        --CVKUtils.MinimalLogFormatter.indent;
-        CVKLOGGER.log(Level.INFO, "---- END {1} ----{0}{0}", new Object[]{System.getProperty("line.separator"), msg});        
-    }
     public static void LogStackTrace() {
         LogStackTrace(Level.INFO);
     }
@@ -196,13 +100,6 @@ public class CVKUtils {
             }
         }
         return false;
-    }
-        
-    public static void VerifyInRenderThread() {
-        if (renderThreadID != 0 && (renderThreadID != Thread.currentThread().getId())) {
-            throw new RuntimeException(String.format("Error: render operation performed from thread %d, render thread %d",
-                    Thread.currentThread().getId(), renderThreadID));
-        }
     }    
     
     public static void checkVKret(int retCode) throws IllegalStateException {
@@ -290,7 +187,7 @@ public class CVKUtils {
      * @return PointerBuffer of validation layers allocated on the provided
      * stack
      */
-    public static PointerBuffer InitVKValidationLayers(MemoryStack stack) {
+    public static PointerBuffer InitVKValidationLayers(MemoryStack stack, CVKGraphLogger logger) {
         IntBuffer pInt = stack.mallocInt(1);
         pInt.put(0);
         pInt.flip();
@@ -298,7 +195,11 @@ public class CVKUtils {
         // Get the count of available layers
         checkVKret(vkEnumerateInstanceLayerProperties(pInt, null));
         int layerCount = pInt.get(0);
-        CVKLOGGER.log(Level.INFO, "Vulkan has {0} available layers.", layerCount);
+        if (logger != null) {
+            logger.info("Vulkan has %d available layers.", layerCount);
+        } else {
+            CVKLOGGER.log(Level.INFO, "Vulkan has {0} available layers.", layerCount);
+        }
 
         // Get available layers
         VkLayerProperties.Buffer availableLayers = VkLayerProperties.mallocStack(layerCount, stack);
@@ -306,7 +207,11 @@ public class CVKUtils {
         for (int i = 0; i < layerCount; ++i) {
             availableLayers.position(i);
             String layerDesc = availableLayers.descriptionString();
-            CVKLOGGER.log(Level.INFO, "Vulkan layer {0}: {1}", new Object[]{i, layerDesc});
+            if (logger != null) {
+                logger.info("\tVulkan layer %d: %s", i, layerDesc);
+            } else {
+                CVKLOGGER.log(Level.INFO, "\tVulkan layer {0}: {1}", new Object[]{i, layerDesc});
+            }            
         }
 
         // Select the best set of validation layers.  If VK_LAYER_KHRONOS_validation


### PR DESCRIPTION
- Created per graph logging and moved logging code to a new CVKGraphLogger class
- Unless called from static code logging should use the logger in the CVKVisualProcessor (which can be accessed through the CVKDevice)
- The VerifyInRenderThread code was static, that was probably ok as all graphs share the same AWT event thread (render thread) but to be safe this was moved to CVKVisualProcessor and is no longer static.
- Removed calls to static cleanup class resources from the visual processor as it made no sense.
- Attempted a thread safe CVKRenderer.Destroy().
- Added code to track VK allocations after having more allocations than my GPU could handle (VKValidation error).
- Fixed some unnessary allocations with staging buffers.
- Fixed a bug with a small atlas where CVKImage was a little too clever and determined the view type which no longer matched what we specified in the shaders
- Fixed resource some state errors that were crashing the icons renderable.