### PR TITLE
Fixed the race condition that could cause a graph to lock up and stop…

### DIFF
--- a/CoreInteractiveGraph/src/au/gov/asd/tac/constellation/graph/interaction/visual/InteractiveVKVisualProcessor.java
+++ b/CoreInteractiveGraph/src/au/gov/asd/tac/constellation/graph/interaction/visual/InteractiveVKVisualProcessor.java
@@ -137,7 +137,7 @@ public class InteractiveVKVisualProcessor extends CVKVisualProcessor implements 
 
         @Override
         public void apply() {
-            //setDrawHitTest(doHitTesting);
+            setDrawHitTest(doHitTesting);
         }
 
         @Override

--- a/CoreVulkanDisplay/src/au/gov/asd/tac/constellation/visual/vulkan/CVKRenderer.java
+++ b/CoreVulkanDisplay/src/au/gov/asd/tac/constellation/visual/vulkan/CVKRenderer.java
@@ -108,9 +108,13 @@ public class CVKRenderer implements ComponentListener {
     private Vector3f clr = new Vector3f(0.0f, 0.0f, 0.0f);
     private boolean requestScreenshot = false;
     private File requestScreenshotFile = null;
+    private boolean drawHitTest = false;
     
     public final CVKGraphLogger GetLogger() { return cvkCanvas.GetLogger(); }
     
+    public void SetDrawHitTest(boolean drawHitTest){
+        this.drawHitTest = drawHitTest;
+    }
 
     // ========================> Lifetime <======================== \\
     
@@ -657,10 +661,12 @@ public class CVKRenderer implements ComponentListener {
                     }
                     
                     // Offscreen Render Pass
-                    List<CVKRenderable> hitTestRenderables = cvkVisualProcessor.GetHitTesterList();
-                    for (CVKRenderable r : renderables) {
-                        r.OffscreenRender(hitTestRenderables); 
-                    }                    
+                    if (drawHitTest) {
+                        List<CVKRenderable> hitTestRenderables = cvkVisualProcessor.GetHitTesterList();
+                        for (CVKRenderable r : renderables) {
+                            r.OffscreenRender(hitTestRenderables); 
+                        }
+                    }
         
                     if (requestScreenshot) {
                         cvkSwapChain.GetImage(imageIndex).SaveToFile(requestScreenshotFile);

--- a/CoreVulkanDisplay/src/au/gov/asd/tac/constellation/visual/vulkan/CVKVisualProcessor.java
+++ b/CoreVulkanDisplay/src/au/gov/asd/tac/constellation/visual/vulkan/CVKVisualProcessor.java
@@ -282,6 +282,27 @@ public class CVKVisualProcessor extends VisualProcessor {
         //cvkCanvas.Destroy();            
     }
 
+        /**
+     * Tell this processor that it should draw the "Hit Test" visualisation as
+     * well as the regular visualisation as part of each frame of the GL
+     * life-cycle.
+     * <p>
+     * The hit-test visualisation is a hidden visualisation that gets drawn to
+     * an off-screen openGL buffer. It fills the background with solid black and
+     * then draws each element using a color whose red value corresponds to that
+     * element's ID.
+     * <p>
+     * This method is intended to be called by subclass processors that utilise
+     * this hit-test visualisation for some form of graph interaction. See the
+     * <code>HitTester</code> class in the Interactive Graph package for a
+     * canonical example.
+     *
+     * @param drawHitTest
+     */
+    protected final void setDrawHitTest(final boolean drawHitTest) {
+        cvkCanvas.GetRenderer().SetDrawHitTest(drawHitTest);
+    }
+    
     private final class GLExportToImageOperation implements VisualOperation {
 
         private final File file;

--- a/CoreVulkanDisplay/src/au/gov/asd/tac/constellation/visual/vulkan/renderables/CVKHitTester.java
+++ b/CoreVulkanDisplay/src/au/gov/asd/tac/constellation/visual/vulkan/renderables/CVKHitTester.java
@@ -40,7 +40,6 @@ import java.util.List;
 import java.util.Queue;
 import java.util.concurrent.BlockingDeque;
 import java.util.concurrent.LinkedBlockingDeque;
-import java.util.logging.Level;
 import org.lwjgl.system.MemoryStack;
 import static org.lwjgl.system.MemoryStack.stackPush;
 import static org.lwjgl.vulkan.VK10.VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
@@ -365,6 +364,15 @@ public class CVKHitTester extends CVKRenderable {
     @Override
     public void IncrementDescriptorTypeRequirements(CVKDescriptorPoolRequirements reqs, CVKDescriptorPoolRequirements perImageReqs) {}       
     
+    // TODO: This code is not being called yet
+    // It updates the hitTestRequest to be the last
+    public void update() {
+        if (requestQueue != null && !requestQueue.isEmpty()) {
+            requestQueue.forEach(request -> notificationQueues.add(request.getNotificationQueue()));
+            hitTestRequest = requestQueue.getLast();
+            requestQueue.clear();
+        }
+    }
     
     // ========================> Display <======================== \\
     
@@ -392,7 +400,7 @@ public class CVKHitTester extends CVKRenderable {
             ret = CreateFrameBuffer();
             if (VkFailed(ret)) { return ret; }  
         }
-                      
+        
         if (requestQueue != null && !requestQueue.isEmpty()) {
             requestQueue.forEach(request -> notificationQueues.add(request.getNotificationQueue()));
             hitTestRequest = requestQueue.getLast();
@@ -434,7 +442,10 @@ public class CVKHitTester extends CVKRenderable {
             }
         }
         
-        needsDisplayUpdate = false;
+        // If there are still requests that need to be processed then continue updating
+        // next frame otherwise we can cause a deadlock with a request response
+        // waiting (blocking the VisualManager) forever for a response.
+        needsDisplayUpdate =  (requestQueue.size() > 0);
         return ret;
     }  
 


### PR DESCRIPTION
 Fixed the race condition that could cause a graph to lock up and stop accepting input.

The issue happened when a hit request, triggered with a blocking return, got stuck on the notification queue in the HitTester and needsUpdate was set to false. The fix now checks for this case and makes sure the HitTester is updated until no requests are left.
